### PR TITLE
API for concert seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
-
+gem "rest-client"
 gem "devise"
 gem "autoprefixer-rails"
 gem "font-awesome-sass", "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -115,6 +117,9 @@ GEM
       sassc (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -136,6 +141,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.7.1)
@@ -148,6 +156,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.2-arm64-darwin)
       racc (~> 1.4)
@@ -198,6 +207,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -230,6 +244,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -268,6 +285,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.5)
+  rest-client
   sassc-rails
   selenium-webdriver
   simple_form!

--- a/app/controllers/concerts_controller.rb
+++ b/app/controllers/concerts_controller.rb
@@ -1,4 +1,9 @@
+require 'open-uri'
+require 'nokogiri'
+
 class ConcertsController < ApplicationController
   def index
+    #it wont be concert.all - it will be based on whatever the user has search
+    @concerts = Concert.all
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,11 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }]
 #   Character.create(name: "Luke", movie: movies.first)
+require "json"
+require "rest-client"
+
+url =
+response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': SETLIST_API_KEY })
 
 puts "creating user seed Bowie"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,11 +5,38 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }]
 #   Character.create(name: "Luke", movie: movies.first)
+puts "Clearing database..."
+Concert.destroy_all
+puts "Concerts destroyed"
+Artist.destroy_all
+puts "Artists destroyed"
+User.destroy_all
+puts "Users destroyed"
+puts "All done!"
+
 require "json"
 require "rest-client"
 
-url =
-response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': SETLIST_API_KEY })
+menzingers = "3071d829-b9ca-4499-b4f5-74d6d8531aed"
+artist = Artist.create(name: "The Menzingers")
+puts "Creating concerts for #{artist.name}"
+
+url = "https://api.setlist.fm/rest/1.0/artist/#{menzingers}/setlists"
+response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': ENV['SETLIST_API_KEY'] })
+
+shows = JSON.parse(response)
+# pp shows
+# pp shows.keys
+shows["setlist"].each do |show|
+  concert = Concert.new
+  concert.city = show["venue"]["city"]
+  concert.venue = show["venue"]["name"]
+  concert.date = show["eventDate"]
+  # concert.artist_id = Artist.first
+  concert.save!
+  puts "Created new concert with id #{concert.id}"
+end
+
 
 puts "creating user seed Bowie"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }]
-#   Character.create(name: "Luke", movie: movies.first)
+require "json"
+require "rest-client"
+
 puts "Clearing database..."
 Concert.destroy_all
 puts "Concerts destroyed"
@@ -14,40 +10,120 @@ User.destroy_all
 puts "Users destroyed"
 puts "All done!"
 
-require "json"
-require "rest-client"
+# Creating artist Menzingers & concert instances for Menzingers
+puts "Creating the artist The Menzingers"
+menzingers = Artist.create(name: "The Menzingers")
+puts "Creating concerts for #{menzingers.name}"
 
-menzingers = "3071d829-b9ca-4499-b4f5-74d6d8531aed"
-artist = Artist.create(name: "The Menzingers")
-puts "Creating concerts for #{artist.name}"
-
-url = "https://api.setlist.fm/rest/1.0/artist/#{menzingers}/setlists"
+url = "https://api.setlist.fm/rest/1.0/artist/3071d829-b9ca-4499-b4f5-74d6d8531aed/setlists"
 response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': ENV['SETLIST_API_KEY'] })
-
 shows = JSON.parse(response)
-# pp shows
-# pp shows.keys
+
 shows["setlist"].each do |show|
   concert = Concert.new
   concert.city = show["venue"]["city"]["name"]
   concert.venue = show["venue"]["name"]
   concert.date = show["eventDate"]
-  concert.artist_id = artist.id
-  concert.save! #not working
-  puts "Created new concert with id #{concert.id}"
+  concert.artist_id = menzingers.id
+  concert.save!
+  puts "Created new concert with id #{concert.id} for #{menzingers.name}"
 end
 
+# Creating artist The Gaslight Anthem and concerts for them
+puts "Creating the artist The Gaslight Anthem"
+gaslight = Artist.create(name: "The Gaslight Anthem")
+puts "Creating concerts for #{gaslight.name}"
+
+url = "https://api.setlist.fm/rest/1.0/artist/f208f09e-b5b3-4b06-87cd-f7230fae17e3/setlists"
+response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': ENV['SETLIST_API_KEY'] })
+shows = JSON.parse(response)
+
+shows["setlist"].each do |show|
+  concert = Concert.new
+  concert.city = show["venue"]["city"]["name"]
+  concert.venue = show["venue"]["name"]
+  concert.date = show["eventDate"]
+  concert.artist_id = gaslight.id
+  concert.save!
+  puts "Created new concert with id #{concert.id} for #{gaslight.name}"
+end
+
+# Creating artist Muse and concerts for them
+puts "Creating the artist Muse"
+muse = Artist.create(name: "Muse")
+puts "Creating concerts for #{muse.name}"
+
+url = "https://api.setlist.fm/rest/1.0/artist/9c9f1380-2516-4fc9-a3e6-f9f61941d090/setlists"
+response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': ENV['SETLIST_API_KEY'] })
+shows = JSON.parse(response)
+
+shows["setlist"].each do |show|
+  concert = Concert.new
+  concert.city = show["venue"]["city"]["name"]
+  concert.venue = show["venue"]["name"]
+  concert.date = show["eventDate"]
+  concert.artist_id = muse.id
+  concert.save!
+  puts "Created new concert with id #{concert.id} for #{muse.name}"
+end
+
+# Creating artist Burna Boy and concerts for them
+puts "Creating the artist Burna Boy"
+burnaboy = Artist.create(name: "Burna Boy")
+puts "Creating concerts for #{burnaboy.name}"
+
+url = "https://api.setlist.fm/rest/1.0/artist/78a19169-ac75-4868-b504-7e2e073118e0/setlists"
+response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': ENV['SETLIST_API_KEY'] })
+shows = JSON.parse(response)
+
+shows["setlist"].each do |show|
+  concert = Concert.new
+  concert.city = show["venue"]["city"]["name"]
+  concert.venue = show["venue"]["name"]
+  concert.date = show["eventDate"]
+  concert.artist_id = burnaboy.id
+  concert.save!
+  puts "Created new concert with id #{concert.id} for #{burnaboy.name}"
+end
+
+# Creating artist Polo & Pan and concerts for them
+puts "Creating the artist Polo & Pan"
+polo_and_pan = Artist.create(name: "Polo & Pan")
+puts "Creating concerts for #{polo_and_pan.name}"
+
+url = "https://api.setlist.fm/rest/1.0/artist/1d9ec7ea-0fa4-41d9-917b-723c735ebbfe/setlists"
+response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': ENV['SETLIST_API_KEY'] })
+shows = JSON.parse(response)
+
+shows["setlist"].each do |show|
+  concert = Concert.new
+  concert.city = show["venue"]["city"]["name"]
+  concert.venue = show["venue"]["name"]
+  concert.date = show["eventDate"]
+  concert.artist_id = polo_and_pan.id
+  concert.save!
+  puts "Created new concert with id #{concert.id} for #{polo_and_pan.name}"
+end
+
+# Creating artist Gojira and concerts for them
+puts "Creating the artist Gojira"
+gojira = Artist.create(name: "Gojira")
+puts "Creating concerts for #{gojira.name}"
+
+url = "https://api.setlist.fm/rest/1.0/artist/1c5efd53-d6b6-4d63-9d22-a15025cf5f07/setlists"
+response = RestClient.get(url, { 'Accept': 'application/json', 'x-api-key': ENV['SETLIST_API_KEY'] })
+shows = JSON.parse(response)
+
+shows["setlist"].each do |show|
+  concert = Concert.new
+  concert.city = show["venue"]["city"]["name"]
+  concert.venue = show["venue"]["name"]
+  concert.date = show["eventDate"]
+  concert.artist_id = gojira.id
+  concert.save!
+  puts "Created new concert with id #{concert.id} for #{gojira.name}"
+end
 
 puts "creating user seed Bowie"
-
 User.create!(username: "Bowie", age: 23, city: "Montreal", bio: "Hello there! I am Bowie, a super cool dude from Montreal", email: "bowie@bowie.com", password: "123456")
-puts "done!"
-
-
-puts "creating artist seed Led Zeppelin "
-Artist.create!(name: "Led Zeppelin")
-puts "done!"
-
-puts "creating a concert seed Olympic Stadium - Led Zeppelin"
-Concert.create!(city: "Montreal", venue: "Olympic Stadium", date: DateTime.new(2001, 2, 3, 4, 5, 6), average_rating: "4.5", artist: Artist.first)
 puts "done!"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ puts "Cleaning the concerts table"
 Concert.destroy_all
 puts "Cleaning the artist table"
 Artist.destroy_all
-puts "Cleaning the users table"
+puts "Cleaning the users table."
 User.destroy_all
 
 # Creating artist Menzingers & concert instances for Menzingers

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,6 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }]
 #   Character.create(name: "Luke", movie: movies.first)
 
-
 puts "creating user seed Bowie"
 
 User.create!(username: "Bowie", age: 23, city: "Montreal", bio: "Hello there! I am Bowie, a super cool dude from Montreal", email: "bowie@bowie.com", password: "123456")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ shows = JSON.parse(response)
 # pp shows.keys
 shows["setlist"].each do |show|
   concert = Concert.new
-  concert.city = show["venue"]["city"]
+  concert.city = show["venue"]["city"]["name"]
   concert.venue = show["venue"]["name"]
   concert.date = show["eventDate"]
-  # concert.artist_id = Artist.first
-  concert.save!
+  concert.artist_id = artist.id
+  concert.save! #not working
   puts "Created new concert with id #{concert.id}"
 end
 


### PR DESCRIPTION
- Accessed the setlist.fm api to get concert details
- Each artist created has a specific id used in that api (you will see the url is updated for each artist)
- Concerts are created per artist and then assigned the artist id
- Also: Added destroys at the beginning of the seed so we're always clearing when we create

-- please note! There's likely a possibility to refactor the concert seed part since it's repeated code for each artist. I will look into this!