### PR TITLE
fixed the error if a filled was empty

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,6 +9,7 @@ class ReviewsController < ApplicationController
   end
 
   def create
+    @attendance = current_user.attendance_info(@concert)
     @review = Review.new(review_params)
     @review.attendance = current_user.attendance_info(@concert)
     if @review.save


### PR DESCRIPTION
Before, if we submitted the form with empty fields, we would get an error 500


![image](https://github.com/daouasof/frontrow/assets/130665835/a7f6df16-4a07-40b0-b9b3-90a79580a4a7)
