### PR TITLE
Front-end fixes!

### DIFF
--- a/app/assets/stylesheets/components/_show-banner.scss
+++ b/app/assets/stylesheets/components/_show-banner.scss
@@ -25,9 +25,14 @@
 
 }
 
-.attended {
+.attending {
   display: flex;
   justify-content: space-between;
   margin-left: 12px;
+  margin-right: 12px;
+}
+
+.attended {
+  text-align: end;
   margin-right: 12px;
 }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,4 +1,7 @@
 // Specific CSS for your home-page
 h4 {
+  margin-top: 20px;
+  margin-bottom: 28px;
   text-align: center;
+  font-weight: bold;
 }

--- a/app/views/concerts/_show_banner.html.erb
+++ b/app/views/concerts/_show_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="show-banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url('<%= cl_image_path @concert.artist.banner.key %>')">
+<div class="show-banner" style="background-image: linear-gradient(rgba(0,0,0,0.6),rgba(0,0,0,0.6)), url('<%= cl_image_path @concert.artist.banner.key %>')">
   <h2><%= concert.artist.name %></h2>
     <div class="container-banner">
       <p> <%= concert.venue %> -  <%= concert.city %> - <%= concert.date.strftime('%d/%m/%Y') %> </p>

--- a/app/views/concerts/_upcoming_banner.html.erb
+++ b/app/views/concerts/_upcoming_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="show-banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url('<%= cl_image_path @concert.artist.banner.key %>')">
+<div class="show-banner" style="background-image: linear-gradient(rgba(0,0,0,0.6),rgba(0,0,0,0.6)), url('<%= cl_image_path @concert.artist.banner.key %>')">
   <h2><%= concert.artist.name %></h2>
     <div class="container-banner">
       <p> <%= concert.venue %> -  <%= concert.city %> - <%= concert.date.strftime('%d/%m/%Y') %> </p>

--- a/app/views/concerts/_upcoming_banner.html.erb
+++ b/app/views/concerts/_upcoming_banner.html.erb
@@ -2,7 +2,7 @@
   <h2><%= concert.artist.name %></h2>
     <div class="container-banner">
       <p> <%= concert.venue %> -  <%= concert.city %> - <%= concert.date.strftime('%d/%m/%Y') %> </p>
-      <p><%= image_tag "pplattended.svg", alt: "people check" %> <%= concert.attendances.count %> users attended</p>
+      <p><%= image_tag "pplattended.svg", alt: "people check" %> <%= concert.attendances.count %> users attending</p>
         <% if current_user.attended?(concert) %>
           <%= link_to "I'm attending", concert_attendances_path(concert), data: { turbo_method: :post }, class:"btn d-none" %>
         <% elsif  %>
@@ -10,7 +10,7 @@
         <% end %>
     </div>
 
-  <div class="attended">
+  <div class="attending">
     <div>
       <%= link_to concert.tickets_url, target: :_blank do %>
         <p>Buy tickets <i class="fa-solid fa-ticket" style="color: #f9f5eb;"></i></p>

--- a/app/views/reviews/_review_banner.html.erb
+++ b/app/views/reviews/_review_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="show-banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url('<%= cl_image_path @concert.artist.photo.key %>')">
+<div class="show-banner" style="background-image: linear-gradient(rgba(0,0,0,0.6),rgba(0,0,0,0.6)), url('<%= cl_image_path @concert.artist.banner.key %>')">
   <h2><%= concert.artist.name %></h2>
     <div class="container-banner">
       <p> <%= concert.venue %> -  <%= concert.city %> - <%= concert.date.strftime('%d/%m/%Y') %> </p>


### PR DESCRIPTION
1. Added more spacing on the Homepage with the titles:
![image](https://github.com/daouasof/frontrow/assets/129611938/5a962435-b814-453c-b91a-9231061849bb)
 
2. Made all the banners a bit darker so the writing pops more
![image](https://github.com/daouasof/frontrow/assets/129611938/b7523cab-5b1a-417a-9982-f0a21020afdf)

3. Banner on the create new review page is the same for all banners

4. Past shows - the I attended is back on the right side
![image](https://github.com/daouasof/frontrow/assets/129611938/01247a0a-9a71-4a99-b1ec-6f1e1c2f27e4)

5. Changed wording for upcoming shows to 'users attending' instead of past tense
![image](https://github.com/daouasof/frontrow/assets/129611938/b7523cab-5b1a-417a-9982-f0a21020afdf)